### PR TITLE
Exploratory work adding Soroban as a target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ Cargo.lock
 /target
 **/*.rs.bk
 bundle.ll
-
+*.wasm
+*.abi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ parse-display = "0.8.0"
 parity-scale-codec = "3.1"
 ink = "4.0.0-beta"
 scale-info = "2.3"
+stellar-xdr = { version = "0.0.12", default-features = false, features = ["std", "next", "base64"] }
 
 [dev-dependencies]
 num-derive = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+build:
+	PATH="$$HOME/.local/bin/llvm14.0/bin:$$PATH" LLVM_SYS_140_PREFIX="$$HOME/.local/bin/llvm14.0" cargo build
+
+install:
+	PATH="$$HOME/.local/bin/llvm14.0/bin:$$PATH" LLVM_SYS_140_PREFIX="$$HOME/.local/bin/llvm14.0" cargo install --path .

--- a/contract.sol
+++ b/contract.sol
@@ -1,0 +1,11 @@
+pragma solidity 0;
+
+contract maxer {
+	function max(uint64 x, uint64 y) public pure returns (uint64) {
+		if (x > y) {
+			return x;
+		} else {
+			return y;
+		}
+	}
+}

--- a/examples/adder.sol
+++ b/examples/adder.sol
@@ -1,8 +1,0 @@
-pragma solidity 0;
-
-contract adder {
-	/// Add the values of x and y together.
-	function add(uint64 x, uint64 y) public pure returns (uint64) {
-		return x + y;
-	}
-}

--- a/examples/adder.sol
+++ b/examples/adder.sol
@@ -1,0 +1,8 @@
+pragma solidity 0;
+
+contract adder {
+	/// Add the values of x and y together.
+	function add(uint32 x, uint32 y) public pure returns (uint32) {
+		return x + y;
+	}
+}

--- a/examples/adder.sol
+++ b/examples/adder.sol
@@ -2,7 +2,7 @@ pragma solidity 0;
 
 contract adder {
 	/// Add the values of x and y together.
-	function add(uint32 x, uint32 y) public pure returns (uint32) {
+	function add(uint64 x, uint64 y) public pure returns (uint64) {
 		return x + y;
 	}
 }

--- a/math.sol
+++ b/math.sol
@@ -1,6 +1,6 @@
 pragma solidity 0;
 
-contract maxer {
+contract math {
 	function max(uint64 x, uint64 y) public pure returns (uint64) {
 		if (x > y) {
 			return x;

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -717,6 +717,7 @@ fn target_arg(matches: &ArgMatches) -> Target {
             value_length: *value_length as usize,
         },
         "evm" => solang::Target::EVM,
+        "soroban" => solang::Target::Soroban,
         _ => unreachable!(),
     };
 

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -66,10 +66,10 @@ fn main() {
                     )
                     .arg(
                         Arg::new("TARGET")
-                            .help("Target to build for [possible values: solana, substrate]")
+                            .help("Target to build for [possible values: solana, substrate, soroban]")
                             .long("target")
                             .num_args(1)
-                            .value_parser(["solana", "substrate", "evm"])
+                            .value_parser(["solana", "substrate", "soroban", "evm"])
                             .hide_possible_values(true)
                             .required(true),
                     )

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -66,7 +66,9 @@ fn main() {
                     )
                     .arg(
                         Arg::new("TARGET")
-                            .help("Target to build for [possible values: solana, substrate, soroban]")
+                            .help(
+                                "Target to build for [possible values: solana, substrate, soroban]",
+                            )
                             .long("target")
                             .num_args(1)
                             .value_parser(["solana", "substrate", "soroban", "evm"])

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -410,6 +410,7 @@ impl BasicBlock {
 #[derive(Clone)]
 pub struct ControlFlowGraph {
     pub name: String,
+    pub original_name: String,
     pub function_no: ASTFunction,
     pub params: Arc<Vec<Parameter>>,
     pub returns: Arc<Vec<Parameter>>,
@@ -432,9 +433,10 @@ pub enum ASTFunction {
 }
 
 impl ControlFlowGraph {
-    pub fn new(name: String, function_no: ASTFunction) -> Self {
+    pub fn new(name: String, function_name: String, function_no: ASTFunction) -> Self {
         let mut cfg = ControlFlowGraph {
             name,
+            original_name: function_name,
             function_no,
             params: Arc::new(Vec::new()),
             returns: Arc::new(Vec::new()),
@@ -457,6 +459,7 @@ impl ControlFlowGraph {
     pub fn placeholder() -> Self {
         ControlFlowGraph {
             name: String::new(),
+            original_name: String::new(),
             function_no: ASTFunction::None,
             params: Arc::new(Vec::new()),
             returns: Arc::new(Vec::new()),
@@ -1534,6 +1537,7 @@ fn function_cfg(
 
     let mut cfg = ControlFlowGraph::new(
         name,
+        func.name.clone(),
         if let Some(num) = function_no {
             ASTFunction::SolidityFunction(num)
         } else {
@@ -1805,7 +1809,7 @@ fn generate_modifier_dispatch(
         chain_no,
         modifier.llvm_symbol(ns)
     );
-    let mut cfg = ControlFlowGraph::new(name, ASTFunction::None);
+    let mut cfg = ControlFlowGraph::new(name.clone(), name, ASTFunction::None);
 
     cfg.params = func.params.clone();
     cfg.returns = func.returns.clone();

--- a/src/codegen/dispatch.rs
+++ b/src/codegen/dispatch.rs
@@ -23,7 +23,11 @@ pub(super) fn function_dispatch(
     opt: &Options,
 ) -> ControlFlowGraph {
     let mut vartab = Vartable::new(ns.next_id);
-    let mut cfg = ControlFlowGraph::new("solang_dispatch".into(), ASTFunction::None);
+    let mut cfg = ControlFlowGraph::new(
+        "solang_dispatch".into(),
+        "solang_dispatch".into(),
+        ASTFunction::None,
+    );
 
     let switch_block = cfg.new_basic_block("switch".to_string());
     let no_function_matched = cfg.new_basic_block("no_function_matched".to_string());

--- a/src/codegen/events/mod.rs
+++ b/src/codegen/events/mod.rs
@@ -47,5 +47,7 @@ pub(super) fn new_event_emitter<'a>(
             ns,
             event_no,
         }),
+
+        Target::Soroban => todo!(),
     }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -228,10 +228,8 @@ fn contract(contract_no: usize, ns: &mut Namespace, opt: &Options) {
 /// This function will set all contract storage initializers and should be called from the constructor
 fn storage_initializer(contract_no: usize, ns: &mut Namespace, opt: &Options) -> ControlFlowGraph {
     // note the single `:` to prevent a name clash with user-declared functions
-    let mut cfg = ControlFlowGraph::new(
-        format!("{}:storage_initializer", ns.contracts[contract_no].name),
-        ASTFunction::None,
-    );
+    let name = format!("{}:storage_initializer", ns.contracts[contract_no].name);
+    let mut cfg = ControlFlowGraph::new(name.clone(), name, ASTFunction::None);
     let mut vartab = Vartable::new(ns.next_id);
 
     for layout in &ns.contracts[contract_no].layout {

--- a/src/codegen/yul/mod.rs
+++ b/src/codegen/yul/mod.rs
@@ -64,7 +64,11 @@ fn yul_function_cfg(
         "{}::yul_function_{}::{}",
         ns.contracts[contract_no].name, function_no, yul_func.name
     );
-    let mut cfg = ControlFlowGraph::new(func_name, ASTFunction::YulFunction(function_no));
+    let mut cfg = ControlFlowGraph::new(
+        func_name.clone(),
+        func_name,
+        ASTFunction::YulFunction(function_no),
+    );
 
     cfg.params = yul_func.params.clone();
     cfg.returns = yul_func.returns.clone();

--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -11,6 +11,7 @@ use num_traits::ToPrimitive;
 use std::collections::HashMap;
 
 use crate::codegen::{cfg::ReturnCode, Options};
+use crate::emit::soroban;
 use crate::emit::substrate;
 use crate::emit::{solana, BinaryOp, Generate};
 use crate::linker::link;
@@ -72,6 +73,9 @@ impl<'a> Binary<'a> {
             }
             Target::Solana => {
                 solana::SolanaTarget::build(context, &std_lib, contract, ns, filename, opt)
+            }
+            Target::Soroban => {
+                soroban::SorobanTarget::build(context, &std_lib, contract, ns, filename, opt)
             }
             Target::EVM => unimplemented!(),
         }

--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -157,20 +157,7 @@ impl<'a> Binary<'a> {
         while let Some(f) = func {
             let name = f.get_name().to_str().unwrap();
 
-            if !name.starts_with("llvm.")
-                && export_list.iter().all(|e| {
-                    // symbols may get renamed foo.1 or foo.2, also export those
-                    if let Some(tail) = name.strip_prefix(e) {
-                        if let Some(no) = tail.strip_prefix('.') {
-                            no.parse::<u32>().is_ok()
-                        } else {
-                            tail.is_empty()
-                        }
-                    } else {
-                        false
-                    }
-                })
-            {
+            if !name.starts_with("llvm.") && !export_list.contains(&name) {
                 f.set_linkage(Linkage::Internal);
             }
 

--- a/src/emit/functions.rs
+++ b/src/emit/functions.rs
@@ -39,8 +39,7 @@ pub(super) fn emit_functions<'a, T: TargetRuntime<'a>>(
 
                 func
             } else {
-                bin.module
-                    .add_function(&cfg.name, ftype, Some(Linkage::Internal))
+                bin.module.add_function(&cfg.name, ftype, None)
             };
 
             bin.functions.insert(cfg_no, func_decl);

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -21,6 +21,7 @@ mod instructions;
 mod loop_builder;
 mod math;
 pub mod solana;
+pub mod soroban;
 mod storage;
 mod strings;
 pub mod substrate;

--- a/src/emit/solana/mod.rs
+++ b/src/emit/solana/mod.rs
@@ -69,7 +69,7 @@ impl SolanaTarget {
         // externals
         target.declare_externals(&mut binary, ns);
 
-        emit_functions(&mut target, &mut binary, contract, ns);
+        emit_functions(&mut target, &mut binary, contract, ns, |cfg| &cfg.name);
 
         binary.internalize(&[
             "entrypoint",

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -36,7 +36,7 @@ impl SorobanTarget {
             None,
         );
 
-        // TODO: emit_functions(&mut SorobanTarget, &mut binary, contract, ns);
+        emit_functions(&mut SorobanTarget, &mut binary, contract, ns);
 
         Self::emit_env_meta_entries(context, &mut binary);
         Self::emit_spec_entries(context, contract, &mut binary);

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -82,7 +82,6 @@ impl SorobanTarget {
             if !cfg.public {
                 continue;
             }
-            cfg.params.iter().count();
             ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
                 name: function_name(&cfg.name)
                     .try_into()

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -54,7 +54,9 @@ impl SorobanTarget {
             // a slice of bytes. As far as I can tell the inkwell interface only
             // provides a way to provide it as a &str, although internally it
             // immediately converts it to a CStr, and LLVM allows non-unicode
-            // characters.
+            // characters. We're currently misusing String's unchecked
+            // conversion function to intentionally get a String that holds
+            // non-utf8 data.
             String::from_utf8_unchecked(meta)
         };
         binary

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -1,3 +1,6 @@
+pub(super) mod target;
+
+use crate::emit::functions::emit_functions;
 use crate::{codegen::Options, emit::Binary, sema::ast};
 use inkwell::context::Context;
 use inkwell::module::Module;
@@ -13,7 +16,7 @@ impl SorobanTarget {
         filename: &'a str,
         opt: &'a Options,
     ) -> Binary<'a> {
-        Binary::new(
+        let mut binary = Binary::new(
             context,
             ns.target,
             &contract.name,
@@ -21,6 +24,8 @@ impl SorobanTarget {
             opt,
             std_lib,
             None,
-        )
+        );
+        emit_functions(&mut SorobanTarget, &mut binary, contract, ns);
+        binary
     }
 }

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -1,0 +1,26 @@
+use crate::{codegen::Options, emit::Binary, sema::ast};
+use inkwell::context::Context;
+use inkwell::module::Module;
+
+pub struct SorobanTarget;
+
+impl SorobanTarget {
+    pub fn build<'a>(
+        context: &'a Context,
+        std_lib: &Module<'a>,
+        contract: &'a ast::Contract,
+        ns: &'a ast::Namespace,
+        filename: &'a str,
+        opt: &'a Options,
+    ) -> Binary<'a> {
+        Binary::new(
+            context,
+            ns.target,
+            &contract.name,
+            filename,
+            opt,
+            std_lib,
+            None,
+        )
+    }
+}

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -5,6 +5,15 @@ use crate::{codegen::Options, emit::Binary, sema::ast};
 use inkwell::context::Context;
 use inkwell::module::Module;
 
+use stellar_xdr::{
+    ScEnvMetaEntry, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, WriteXdr,
+};
+
+// TODO: Handle error cases that are currently caught with .expect. Figure out
+// how to return errors from build.
+
+const SOROBAN_ENV_INTERFACE_VERSION: u64 = 27;
+
 pub struct SorobanTarget;
 
 impl SorobanTarget {
@@ -25,7 +34,129 @@ impl SorobanTarget {
             std_lib,
             None,
         );
+
         // TODO: emit_functions(&mut SorobanTarget, &mut binary, contract, ns);
+
+        Self::emit_env_meta_entries(context, &mut binary);
+        Self::emit_spec_entries(context, contract, &mut binary);
+
         binary
+    }
+
+    fn emit_env_meta_entries<'a>(context: &'a Context, binary: &mut Binary<'a>) {
+        let mut meta = vec![];
+        ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(SOROBAN_ENV_INTERFACE_VERSION)
+            .write_xdr(&mut meta)
+            .expect("writing env meta interface version to xdr");
+        let meta = unsafe {
+            // TODO: Figure out the right way to generate the LLVM metadata for
+            // a slice of bytes. As far as I can tell the inkwell interface only
+            // provides a way to provide it as a &str, although internally it
+            // immediately converts it to a CStr, and LLVM allows non-unicode
+            // characters.
+            String::from_utf8_unchecked(meta)
+        };
+        binary
+            .module
+            .add_global_metadata(
+                "wasm.custom_sections",
+                &context.metadata_node(&[
+                    context.metadata_string("contractenvmetav0").into(),
+                    context.metadata_string(meta.as_str()).into(),
+                ]),
+            )
+            .expect("adding env meta as metadata");
+    }
+
+    fn emit_spec_entries<'a>(
+        context: &'a Context,
+        contract: &'a ast::Contract,
+        binary: &mut Binary<'a>,
+    ) {
+        // TODO: Emit custom type spec entries.
+        let mut spec = vec![];
+        for cfg in &contract.cfg {
+            if cfg.is_placeholder() {
+                continue;
+            }
+            if !cfg.public {
+                continue;
+            }
+            cfg.params.iter().count();
+            ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+                name: function_name(&cfg.name)
+                    .try_into()
+                    .expect(format!("function name {:?} exceeds limit", cfg.name).as_str()),
+                inputs: cfg
+                    .params
+                    .iter()
+                    .enumerate()
+                    .map(|(i, p)| ScSpecFunctionInputV0 {
+                        name: p
+                            .id
+                            .as_ref()
+                            .map(|id| id.to_string())
+                            .unwrap_or_else(|| i.to_string())
+                            .try_into()
+                            .expect("function input name exceeds limit"),
+                        type_: ScSpecTypeDef::U32, // TODO: Map type.
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .expect("function input count exceeds limit"),
+                outputs: cfg
+                    .returns
+                    .iter()
+                    .map(|_| ScSpecTypeDef::U32) // TODO: Map type.
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .expect("function output count exceeds limit"),
+            })
+            .write_xdr(&mut spec)
+            .expect(format!("writing spec to xdr for function {}", cfg.name).as_str());
+        }
+        let spec = unsafe {
+            // TODO: See comment in emit_env_meta_entries.
+            String::from_utf8_unchecked(spec)
+        };
+        binary
+            .module
+            .add_global_metadata(
+                "wasm.custom_sections",
+                &context.metadata_node(&[
+                    context.metadata_string("contractspecv0").into(),
+                    context.metadata_string(spec.as_str()).into(),
+                ]),
+            )
+            .expect("adding spec as metadata");
+    }
+}
+
+fn function_name<'a>(s: &'a str) -> &'a str {
+    // Function names in the control flow graph are fully qualified and include
+    // other information like the types of parameters. There's also special
+    // cases where they contain information about whether they are a constructor
+    // or a user function.
+
+    // TODO: Find a better way to extract the original function name without the
+    // additional. We might need to change the name value from a String to a
+    // type that stores the information in separate fields. There also might be
+    // a better way to do it than this which we're overlooking.
+
+    let mut iter = s.splitn(4, "::");
+    _ = iter.next().unwrap();
+    _ = iter.next().unwrap();
+    let kind = iter.next().unwrap();
+    let name = iter.next().unwrap();
+    match kind {
+        "constructor" => "init",
+        _ => {
+            let name = name.splitn(2, "__").next().unwrap();
+            if name.len() <= 10 {
+                name
+            } else {
+                &name[..10]
+            }
+        }
     }
 }

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -150,7 +150,7 @@ fn function_name<'a>(s: &'a str) -> &'a str {
     let name = iter.next().unwrap();
     match kind {
         "constructor" => "init",
-        _ => {
+        "function" => {
             let name = name.splitn(2, "__").next().unwrap();
             if name.len() <= SOROBAN_SYMBOL_MAX_LENGTH {
                 name
@@ -158,5 +158,6 @@ fn function_name<'a>(s: &'a str) -> &'a str {
                 &name[..SOROBAN_SYMBOL_MAX_LENGTH]
             }
         }
+        _ => panic!("unsupported function kind {:?}", s),
     }
 }

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -13,6 +13,7 @@ use stellar_xdr::{
 // how to return errors from build.
 
 const SOROBAN_ENV_INTERFACE_VERSION: u64 = 27;
+const SOROBAN_SYMBOL_MAX_LENGTH: usize = 10;
 
 pub struct SorobanTarget;
 
@@ -151,10 +152,10 @@ fn function_name<'a>(s: &'a str) -> &'a str {
         "constructor" => "init",
         _ => {
             let name = name.splitn(2, "__").next().unwrap();
-            if name.len() <= 10 {
+            if name.len() <= SOROBAN_SYMBOL_MAX_LENGTH {
                 name
             } else {
-                &name[..10]
+                &name[..SOROBAN_SYMBOL_MAX_LENGTH]
             }
         }
     }

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -25,7 +25,7 @@ impl SorobanTarget {
             std_lib,
             None,
         );
-        emit_functions(&mut SorobanTarget, &mut binary, contract, ns);
+        // TODO: emit_functions(&mut SorobanTarget, &mut binary, contract, ns);
         binary
     }
 }

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -132,7 +132,12 @@ fn function_name<'a>(s: &'a str) -> &'a str {
     }
 }
 
-fn add_custom_section<'a>(context: &'a Context, module: &Module<'a>, name: &'a str, value: Vec<u8>) {
+fn add_custom_section<'a>(
+    context: &'a Context,
+    module: &Module<'a>,
+    name: &'a str,
+    value: Vec<u8>,
+) {
     let value_str = unsafe {
         // TODO: Figure out the right way to generate the LLVM metadata for
         // a slice of bytes. As far as I can tell the inkwell interface only

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -54,7 +54,7 @@ impl SorobanTarget {
             .filter(|cfg| !cfg.is_placeholder())
             .filter(|cfg| cfg.public)
             .filter(|cfg| cfg.original_name.len() > 0)
-            .map(|cfg| cfg.name.as_str())
+            .map(|cfg| cfg.original_name.as_str())
             .collect::<Vec<_>>();
         binary.internalize(&exports);
     }

--- a/src/emit/soroban/target.rs
+++ b/src/emit/soroban/target.rs
@@ -1,16 +1,17 @@
-use crate::codegen::cfg::{HashTy, ReturnCode};
+use crate::codegen::cfg::HashTy;
 use crate::codegen::Expression;
 use crate::emit::binary::Binary;
 use crate::emit::soroban::SorobanTarget;
 use crate::emit::{TargetRuntime, Variable};
 use crate::sema::ast;
 use crate::sema::ast::{Contract, Function, Namespace, Type};
-use inkwell::types::{BasicType, IntType};
+use inkwell::types::IntType;
 use inkwell::values::{
     ArrayValue, BasicMetadataValueEnum, BasicValueEnum, FunctionValue, IntValue, PointerValue,
 };
 use std::collections::HashMap;
 
+#[allow(unused_variables)] // TODO: Remove when implementing TargetRuntime.
 impl<'a> TargetRuntime<'a> for SorobanTarget {
     fn abi_decode<'b>(
         &self,

--- a/src/emit/soroban/target.rs
+++ b/src/emit/soroban/target.rs
@@ -1,0 +1,375 @@
+use crate::codegen::cfg::{HashTy, ReturnCode};
+use crate::codegen::Expression;
+use crate::emit::binary::Binary;
+use crate::emit::soroban::SorobanTarget;
+use crate::emit::{TargetRuntime, Variable};
+use crate::sema::ast;
+use crate::sema::ast::{Contract, Function, Namespace, Type};
+use inkwell::types::{BasicType, IntType};
+use inkwell::values::{
+    ArrayValue, BasicMetadataValueEnum, BasicValueEnum, FunctionValue, IntValue, PointerValue,
+};
+use std::collections::HashMap;
+
+impl<'a> TargetRuntime<'a> for SorobanTarget {
+    fn abi_decode<'b>(
+        &self,
+        bin: &Binary<'b>,
+        function: FunctionValue<'b>,
+        args: &mut Vec<BasicValueEnum<'b>>,
+        data: PointerValue<'b>,
+        length: IntValue<'b>,
+        spec: &[ast::Parameter],
+        ns: &Namespace,
+    ) {
+        unimplemented!();
+    }
+
+    /// Abi encode with optional four bytes selector. The load parameter should be set if the args are
+    /// pointers to data, not the actual data  itself.
+    fn abi_encode(
+        &self,
+        bin: &Binary<'a>,
+        selector: Option<IntValue<'a>>,
+        load: bool,
+        function: FunctionValue<'a>,
+        args: &[BasicValueEnum<'a>],
+        tys: &[Type],
+        ns: &Namespace,
+    ) -> (PointerValue<'a>, IntValue<'a>) {
+        unimplemented!();
+    }
+
+    /// ABI encode into a vector for abi.encode* style builtin functions
+    fn abi_encode_to_vector<'b>(
+        &self,
+        binary: &Binary<'b>,
+        function: FunctionValue<'b>,
+        packed: &[BasicValueEnum<'b>],
+        args: &[BasicValueEnum<'b>],
+        tys: &[Type],
+        ns: &Namespace,
+    ) -> PointerValue<'b> {
+        unimplemented!();
+    }
+
+    fn get_storage_int(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue,
+        slot: PointerValue<'a>,
+        ty: IntType<'a>,
+    ) -> IntValue<'a> {
+        unimplemented!()
+    }
+
+    fn storage_load(
+        &self,
+        binary: &Binary<'a>,
+        ty: &ast::Type,
+        slot: &mut IntValue<'a>,
+        function: FunctionValue<'a>,
+        ns: &ast::Namespace,
+    ) -> BasicValueEnum<'a> {
+        unimplemented!();
+    }
+
+    /// Recursively store a type to storage
+    fn storage_store(
+        &self,
+        binary: &Binary<'a>,
+        ty: &ast::Type,
+        existing: bool,
+        slot: &mut IntValue<'a>,
+        dest: BasicValueEnum<'a>,
+        function: FunctionValue<'a>,
+        ns: &ast::Namespace,
+    ) {
+        unimplemented!();
+    }
+
+    /// Recursively clear storage. The default implementation is for slot-based storage
+    fn storage_delete(
+        &self,
+        bin: &Binary<'a>,
+        ty: &Type,
+        slot: &mut IntValue<'a>,
+        function: FunctionValue<'a>,
+        ns: &Namespace,
+    ) {
+        unimplemented!();
+    }
+
+    // Bytes and string have special storage layout
+    fn set_storage_string(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue<'a>,
+        slot: PointerValue<'a>,
+        dest: BasicValueEnum<'a>,
+    ) {
+        unimplemented!();
+    }
+
+    fn get_storage_string(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue,
+        slot: PointerValue<'a>,
+    ) -> PointerValue<'a> {
+        unimplemented!();
+    }
+
+    fn set_storage_extfunc(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue,
+        slot: PointerValue,
+        dest: PointerValue,
+    ) {
+        unimplemented!();
+    }
+
+    fn get_storage_extfunc(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue,
+        slot: PointerValue<'a>,
+        ns: &Namespace,
+    ) -> PointerValue<'a> {
+        unimplemented!();
+    }
+
+    fn get_storage_bytes_subscript(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue,
+        slot: IntValue<'a>,
+        index: IntValue<'a>,
+    ) -> IntValue<'a> {
+        unimplemented!();
+    }
+
+    fn set_storage_bytes_subscript(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue,
+        slot: IntValue<'a>,
+        index: IntValue<'a>,
+        value: IntValue<'a>,
+    ) {
+        unimplemented!();
+    }
+
+    fn storage_subscript(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue<'a>,
+        ty: &Type,
+        slot: IntValue<'a>,
+        index: BasicValueEnum<'a>,
+        ns: &Namespace,
+    ) -> IntValue<'a> {
+        unimplemented!();
+    }
+
+    fn storage_push(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue<'a>,
+        ty: &Type,
+        slot: IntValue<'a>,
+        val: Option<BasicValueEnum<'a>>,
+        ns: &Namespace,
+    ) -> BasicValueEnum<'a> {
+        unimplemented!();
+    }
+
+    fn storage_pop(
+        &self,
+        bin: &Binary<'a>,
+        function: FunctionValue<'a>,
+        ty: &Type,
+        slot: IntValue<'a>,
+        load: bool,
+        ns: &Namespace,
+    ) -> Option<BasicValueEnum<'a>> {
+        unimplemented!();
+    }
+
+    fn storage_array_length(
+        &self,
+        _bin: &Binary<'a>,
+        _function: FunctionValue,
+        _slot: IntValue<'a>,
+        _elem_ty: &Type,
+        _ns: &Namespace,
+    ) -> IntValue<'a> {
+        unimplemented!();
+    }
+
+    /// keccak256 hash
+    fn keccak256_hash(
+        &self,
+        bin: &Binary<'a>,
+        src: PointerValue,
+        length: IntValue,
+        dest: PointerValue,
+        ns: &Namespace,
+    ) {
+        unimplemented!();
+    }
+
+    /// Prints a string
+    fn print(&self, bin: &Binary, string: PointerValue, length: IntValue) {
+        unimplemented!();
+    }
+
+    /// Return success without any result
+    fn return_empty_abi(&self, bin: &Binary) {
+        unimplemented!();
+    }
+
+    /// Return failure code
+    fn return_code<'b>(&self, bin: &'b Binary, ret: IntValue<'b>) {
+        unimplemented!();
+    }
+
+    /// Return success with the ABI encoded result
+    fn return_abi<'b>(&self, bin: &'b Binary, data: PointerValue<'b>, length: IntValue) {
+        unimplemented!();
+    }
+
+    /// Return failure without any result
+    fn assert_failure<'b>(&self, bin: &'b Binary, data: PointerValue, length: IntValue) {
+        unimplemented!();
+    }
+
+    fn builtin_function(
+        &self,
+        binary: &Binary<'a>,
+        function: FunctionValue<'a>,
+        builtin_func: &Function,
+        args: &[BasicMetadataValueEnum<'a>],
+        ns: &Namespace,
+    ) -> BasicValueEnum<'a> {
+        unimplemented!();
+    }
+
+    /// Calls constructor
+    fn create_contract<'b>(
+        &mut self,
+        bin: &Binary<'b>,
+        function: FunctionValue<'b>,
+        success: Option<&mut BasicValueEnum<'b>>,
+        contract_no: usize,
+        address: PointerValue<'b>,
+        encoded_args: BasicValueEnum<'b>,
+        encoded_args_len: BasicValueEnum<'b>,
+        gas: IntValue<'b>,
+        value: Option<IntValue<'b>>,
+        salt: Option<IntValue<'b>>,
+        seeds: Option<(PointerValue<'b>, IntValue<'b>)>,
+        ns: &Namespace,
+    ) {
+        unimplemented!();
+    }
+
+    /// call external function
+    fn external_call<'b>(
+        &self,
+        bin: &Binary<'b>,
+        function: FunctionValue<'b>,
+        success: Option<&mut BasicValueEnum<'b>>,
+        payload: PointerValue<'b>,
+        payload_len: IntValue<'b>,
+        address: Option<PointerValue<'b>>,
+        gas: IntValue<'b>,
+        value: IntValue<'b>,
+        accounts: Option<(PointerValue<'b>, IntValue<'b>)>,
+        seeds: Option<(PointerValue<'b>, IntValue<'b>)>,
+        ty: ast::CallTy,
+        ns: &Namespace,
+    ) {
+        unimplemented!();
+    }
+
+    /// send value to address
+    fn value_transfer<'b>(
+        &self,
+        _bin: &Binary<'b>,
+        _function: FunctionValue,
+        _success: Option<&mut BasicValueEnum<'b>>,
+        _address: PointerValue<'b>,
+        _value: IntValue<'b>,
+        _ns: &Namespace,
+    ) {
+        unimplemented!();
+    }
+
+    /// builtin expressions
+    fn builtin<'b>(
+        &self,
+        bin: &Binary<'b>,
+        expr: &Expression,
+        vartab: &HashMap<usize, Variable<'b>>,
+        function: FunctionValue<'b>,
+        ns: &Namespace,
+    ) -> BasicValueEnum<'b> {
+        unimplemented!();
+    }
+
+    /// Return the return data from an external call (either revert error or return values)
+    fn return_data<'b>(&self, bin: &Binary<'b>, function: FunctionValue<'b>) -> PointerValue<'b> {
+        unimplemented!();
+    }
+
+    /// Return the value we received
+    fn value_transferred<'b>(&self, binary: &Binary<'b>, ns: &Namespace) -> IntValue<'b> {
+        unimplemented!();
+    }
+
+    /// Terminate execution, destroy bin and send remaining funds to addr
+    fn selfdestruct<'b>(&self, binary: &Binary<'b>, addr: ArrayValue<'b>, ns: &Namespace) {
+        unimplemented!();
+    }
+
+    /// Crypto Hash
+    fn hash<'b>(
+        &self,
+        bin: &Binary<'b>,
+        function: FunctionValue<'b>,
+        hash: HashTy,
+        string: PointerValue<'b>,
+        length: IntValue<'b>,
+        ns: &Namespace,
+    ) -> IntValue<'b> {
+        unimplemented!();
+    }
+
+    /// Emit event
+    fn emit_event<'b>(
+        &self,
+        bin: &Binary<'b>,
+        contract: &Contract,
+        function: FunctionValue<'b>,
+        event_no: usize,
+        data: &[BasicValueEnum<'b>],
+        data_tys: &[Type],
+        topics: &[BasicValueEnum<'b>],
+        topic_tys: &[Type],
+        ns: &Namespace,
+    ) {
+        unimplemented!();
+    }
+
+    /// Return ABI encoded data
+    fn return_abi_data<'b>(
+        &self,
+        binary: &Binary<'b>,
+        data: PointerValue<'b>,
+        data_len: BasicValueEnum<'b>,
+    ) {
+        unimplemented!();
+    }
+}

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -167,7 +167,7 @@ impl SubstrateTarget {
 
         target.declare_externals(&binary);
 
-        emit_functions(&mut target, &mut binary, contract, ns);
+        emit_functions(&mut target, &mut binary, contract, ns, |cfg| &cfg.name);
 
         target.emit_deploy(&mut binary, contract, ns);
         target.emit_call(&binary, contract, ns);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ pub enum Target {
     },
     /// Ethereum EVM, see <https://ethereum.org/en/developers/docs/evm/>
     EVM,
+    /// Soroban, see <https://soroban.stellar.org/docs>
+    Soroban,
 }
 
 impl fmt::Display for Target {
@@ -39,6 +41,7 @@ impl fmt::Display for Target {
             Target::Solana => write!(f, "solana"),
             Target::Substrate { .. } => write!(f, "substrate"),
             Target::EVM => write!(f, "evm"),
+            Target::Soroban => write!(f, "soroban"),
         }
     }
 }
@@ -51,6 +54,7 @@ impl PartialEq for Target {
             Target::Solana => matches!(other, Target::Solana),
             Target::Substrate { .. } => matches!(other, Target::Substrate { .. }),
             Target::EVM => matches!(other, Target::EVM),
+            Target::Soroban => matches!(other, Target::Soroban),
         }
     }
 }
@@ -75,6 +79,7 @@ impl Target {
             "solana" => Some(Target::Solana),
             "substrate" => Some(Target::default_substrate()),
             "evm" => Some(Target::EVM),
+            "soroban" => Some(Target::Soroban),
             _ => None,
         }
     }

--- a/src/linker/wasm.rs
+++ b/src/linker/wasm.rs
@@ -31,9 +31,9 @@ pub fn link(input: &[u8], name: &str) -> Vec<u8> {
 
     command_line.push(CString::new("--export-dynamic").unwrap());
 
-    command_line.push(CString::new("--import-memory").unwrap());
-    command_line.push(CString::new("--initial-memory=1048576").unwrap());
-    command_line.push(CString::new("--max-memory=1048576").unwrap());
+    // command_line.push(CString::new("--import-memory").unwrap());
+    // command_line.push(CString::new("--initial-memory=1048576").unwrap());
+    // command_line.push(CString::new("--max-memory=1048576").unwrap());
 
     command_line.push(
         CString::new(
@@ -61,27 +61,27 @@ pub fn link(input: &[u8], name: &str) -> Vec<u8> {
         parity_wasm::deserialize_buffer(&output).expect("cannot deserialize llvm wasm");
 
     {
-        let imports = module.import_section_mut().unwrap().entries_mut();
-        let mut ind = 0;
+        // let imports = module.import_section_mut().unwrap().entries_mut();
+        // let mut ind = 0;
 
-        while ind < imports.len() {
-            if imports[ind].field().starts_with("seal") {
-                let module_name = match imports[ind].field() {
-                    "seal_set_storage" => "seal2",
-                    "seal_clear_storage"
-                    | "seal_contains_storage"
-                    | "seal_get_storage"
-                    | "seal_instantiate"
-                    | "seal_terminate"
-                    | "seal_random"
-                    | "seal_call" => "seal1",
-                    _ => "seal0",
-                };
-                *imports[ind].module_mut() = module_name.to_owned();
-            }
+        // while ind < imports.len() {
+        //     if imports[ind].field().starts_with("seal") {
+        //         let module_name = match imports[ind].field() {
+        //             "seal_set_storage" => "seal2",
+        //             "seal_clear_storage"
+        //             | "seal_contains_storage"
+        //             | "seal_get_storage"
+        //             | "seal_instantiate"
+        //             | "seal_terminate"
+        //             | "seal_random"
+        //             | "seal_call" => "seal1",
+        //             _ => "seal0",
+        //         };
+        //         *imports[ind].module_mut() = module_name.to_owned();
+        //     }
 
-            ind += 1;
-        }
+        //     ind += 1;
+        // }
     }
 
     // remove empty initializers

--- a/src/linker/wasm.rs
+++ b/src/linker/wasm.rs
@@ -29,10 +29,7 @@ pub fn link(input: &[u8], name: &str) -> Vec<u8> {
         CString::new("--global-base=0").unwrap(),
     ];
 
-    command_line.push(CString::new("--export").unwrap());
-    command_line.push(CString::new("deploy").unwrap());
-    command_line.push(CString::new("--export").unwrap());
-    command_line.push(CString::new("call").unwrap());
+    command_line.push(CString::new("--export-dynamic").unwrap());
 
     command_line.push(CString::new("--import-memory").unwrap());
     command_line.push(CString::new("--initial-memory=1048576").unwrap());

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -1640,4 +1640,6 @@ impl Namespace {
         let symbol = Symbol::UserType(pt::Loc::Builtin, type_no);
         assert!(self.add_symbol(file_no, None, &id, symbol));
     }
+
+    pub fn add_soroban_builtins(&mut self) {}
 }

--- a/src/sema/namespace.rs
+++ b/src/sema/namespace.rs
@@ -32,6 +32,7 @@ impl Namespace {
                 value_length,
             } => (address_length, value_length),
             Target::Solana => (32, 8),
+            Target::Soroban => (32, 8),
         };
 
         let mut ns = Namespace {
@@ -59,6 +60,7 @@ impl Namespace {
         match target {
             Target::Solana => ns.add_solana_builtins(),
             Target::Substrate { .. } => ns.add_substrate_builtins(),
+            Target::Soroban => ns.add_soroban_builtins(),
             _ => {}
         }
 

--- a/src/sema/yul/builtin.rs
+++ b/src/sema/yul/builtin.rs
@@ -20,6 +20,7 @@ impl YulBuiltinPrototype {
             Target::EVM => self.availability[0],
             Target::Substrate { .. } => self.availability[1],
             Target::Solana => self.availability[2],
+            Target::Soroban => todo!(),
         }
     }
 }


### PR DESCRIPTION
This pull request exists to track an exploratory look at what would be required to add Soroban as a target to Solang.

The primary goal is to learn and fill gaps in our knowledge, and to determine how feasible it would be to add Soroban as a target.

A secondary goal is to learn how compatible Soroban is with the concepts that exist in Solidity contracts, and those learnings may inform or alter Soroban itself. It's one thing to do this assessment thereotically, but another to do it concretely by using a tool like Solang as a vehicle that already provides mappings between Solidity and other non-EVM blockchains.

The implementation in this pull request is rudimentary and will take shortcuts. It isn't intended to be an implementation that would be proposed to be included upstream. Hopefully though it might lead us to contributing an implementation in the future.

Related to https://github.com/hyperledger/solang/issues/1129

cc @JakeUrban @tomerweller @graydon